### PR TITLE
fix: add common Pandoc install paths for PDF/DOCX export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tauri-app",
-  "version": "0.9.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tauri-app",
-      "version": "0.9.2",
+      "version": "1.1.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -407,13 +407,30 @@ fn export_pdf_blocking(markdown_content: String, output_path: String, app: tauri
     let _ = fs::create_dir_all(&tmp_dir);
     let tmp_md = tmp_dir.join("export.md");
 
-    // Build PATH: inherit system PATH and append known TeX locations
+    // Build PATH: inherit system PATH and append known Pandoc + TeX locations
     let sys_path = std::env::var("PATH").unwrap_or_default();
     let path_env = if cfg!(target_os = "windows") {
-        // Windows: append common MiKTeX/TeX Live paths
-        format!("{};C:\\Program Files\\MiKTeX\\miktex\\bin\\x64;C:\\texlive\\2024\\bin\\windows;C:\\texlive\\2025\\bin\\windows", sys_path)
+        // Windows: append common Pandoc, MiKTeX, and TeX Live paths
+        let mut extra = format!(
+            "{};C:\\Program Files\\Pandoc;C:\\Program Files\\MiKTeX\\miktex\\bin\\x64;C:\\texlive\\2024\\bin\\windows;C:\\texlive\\2025\\bin\\windows",
+            sys_path
+        );
+        // Also check %LOCALAPPDATA%\Pandoc (user-level MSI install)
+        if let Ok(local_app) = std::env::var("LOCALAPPDATA") {
+            extra = format!("{};{}\\Pandoc", extra, local_app);
+        }
+        extra
     } else {
-        format!("{}:/Library/TeX/texbin:/opt/anaconda3/bin:/usr/local/bin:/usr/bin:/bin", sys_path)
+        // macOS/Linux: add Homebrew (Apple Silicon + Intel), TeX, and common bin paths
+        let mut extra = format!(
+            "{}:/opt/homebrew/bin:/Library/TeX/texbin:/opt/anaconda3/bin:/usr/local/bin:/usr/bin:/bin",
+            sys_path
+        );
+        // Also check ~/.local/bin (pip/pipx installs on Linux)
+        if let Ok(home) = std::env::var("HOME") {
+            extra = format!("{}:{}/bin:{}/.local/bin", extra, home, home);
+        }
+        extra
     };
 
     // Step 1: Extract mermaid blocks, render to PNG via mermaid.ink API
@@ -613,9 +630,23 @@ async fn export_docx(markdown_content: String, output_path: String) -> Result<St
 
             let sys_path = std::env::var("PATH").unwrap_or_default();
             let path_env = if cfg!(target_os = "windows") {
-                format!("{};C:\\Program Files\\MiKTeX\\miktex\\bin\\x64;C:\\texlive\\2024\\bin\\windows;C:\\texlive\\2025\\bin\\windows", sys_path)
+                let mut extra = format!(
+                    "{};C:\\Program Files\\Pandoc;C:\\Program Files\\MiKTeX\\miktex\\bin\\x64;C:\\texlive\\2024\\bin\\windows;C:\\texlive\\2025\\bin\\windows",
+                    sys_path
+                );
+                if let Ok(local_app) = std::env::var("LOCALAPPDATA") {
+                    extra = format!("{};{}\\Pandoc", extra, local_app);
+                }
+                extra
             } else {
-                format!("{}:/Library/TeX/texbin:/usr/local/bin:/usr/bin:/bin", sys_path)
+                let mut extra = format!(
+                    "{}:/opt/homebrew/bin:/Library/TeX/texbin:/usr/local/bin:/usr/bin:/bin",
+                    sys_path
+                );
+                if let Ok(home) = std::env::var("HOME") {
+                    extra = format!("{}:{}/bin:{}/.local/bin", extra, home, home);
+                }
+                extra
             };
 
             let stderr_file = tmp_dir.join("pandoc_stderr.log");

--- a/src/main.ts
+++ b/src/main.ts
@@ -2090,10 +2090,10 @@ async function exportPDF() {
     unlisten();
     console.error("PDF export failed:", e);
     const err = String(e);
-    if (err.toLowerCase().includes("pandoc")) {
+    if (err.toLowerCase().includes("pandoc not found")) {
       showPandocInstallGuide("PDF");
     } else if (statusWords) {
-      statusWords.textContent = `PDF failed: ${err}`;
+      statusWords.textContent = `PDF failed: ${err.length > 200 ? err.slice(0, 200) + "…" : err}`;
       statusWords.style.color = "var(--error)";
       setTimeout(() => {
         statusWords.textContent = prevText;
@@ -3417,7 +3417,7 @@ async function exportDOCX() {
     flashStatus("DOCX exported!", "var(--success)", 3000);
   } catch (e) {
     const err = String(e);
-    if (err.toLowerCase().includes("pandoc")) {
+    if (err.toLowerCase().includes("pandoc") && (err.toLowerCase().includes("not found") || err.toLowerCase().includes("not installed") || err.toLowerCase().includes("is pandoc installed"))) {
       showPandocInstallGuide("DOCX");
     } else {
       flashStatus(`Export failed: ${err}`, "var(--error)", 4000);


### PR DESCRIPTION
## Summary
- Add common Pandoc installation directories to PATH so the app can find pandoc even when launched as a GUI app (Windows: `C:\Program Files\Pandoc`, `%LOCALAPPDATA%\Pandoc`; macOS: `/opt/homebrew/bin`; Linux: `~/.local/bin`, `~/bin`)
- Fix frontend error handler to only show "install Pandoc" guide when pandoc is genuinely not found, not for other pandoc-related errors (e.g. TeX engine failures)
- Applies to both PDF and DOCX export paths

## Test plan
- [ ] Install Pandoc via MSI on Windows, verify PDF export works without adding pandoc to system PATH manually
- [ ] Install Pandoc via Homebrew on Apple Silicon Mac, verify PDF export works
- [ ] Trigger a TeX engine error (e.g. missing basictex) and verify the error message is shown instead of the misleading "install Pandoc" dialog

Fixes #126

https://claude.ai/code/session_01SDLaVBgEoMjT8avyQh2xcA